### PR TITLE
Add optional native clipboard support. 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,13 +10,19 @@ keywords = ["gui", "widgets", "graphics"]
 categories = ["gui"]
 readme = "README.md"
 license = "MIT"
-
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-fltk = { version = "1.1", features = ["enable-glwindow"] }
+fltk = { version = "1", features = ["enable-glwindow"] }
 gl = "0.14"
 egui = "0.14"
+
+[dependencies.copypasta]
+version = "0.7"
+optional = true
+
+[features]
+clipboard = ["copypasta"]
 
 [dev-dependencies]
 egui_demo_lib = "0.14"

--- a/README.md
+++ b/README.md
@@ -16,3 +16,4 @@ https://github.com/fltk-rs/demos/tree/master/egui-demo
 ## Todo
 - Properly handle resizing the GlutWindow: ✅
 - Support egui_demo_lib crate directly: ✅
+- Clipboard support (via optional features): ✅

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -1,5 +1,9 @@
+use egui_backend::{
+    egui,
+    fltk::{enums::*, prelude::*, *},
+    gl, DpiScaling,
+};
 use fltk_egui as egui_backend;
-use egui_backend::{fltk::{enums::*, prelude::*, *}, DpiScaling, egui, gl};
 use std::rc::Rc;
 use std::{cell::RefCell, time::Instant};
 
@@ -33,12 +37,8 @@ fn main() {
         | enums::Event::Resize
         | enums::Event::Move
         | enums::Event::Drag => {
-		    let mut state = state.borrow_mut();
-            state.fuse_input(
-                win,
-                ev,
-                &mut painter.borrow_mut(),
-            );
+            let mut state = state.borrow_mut();
+            state.fuse_input(win, ev, &mut painter.borrow_mut());
             true
         }
         _ => false,
@@ -82,19 +82,19 @@ fn main() {
         });
 
         let (egui_output, paint_cmds) = egui_ctx.end_frame();
-		state.fuse_output(&mut win, &egui_output);
-		
+        state.fuse_output(&mut win, &egui_output);
+
         let paint_jobs = egui_ctx.tessellate(paint_cmds);
 
         //Draw egui texture
         painter.paint_jobs(None, paint_jobs, &egui_ctx.texture());
-		
-		win.swap_buffers();
+
+        win.swap_buffers();
         win.flush();
-		
-		if egui_output.needs_repaint {
-			// let egui doing some animations.
-			app::awake()
+
+        if egui_output.needs_repaint {
+            // let egui doing some animations.
+            app::awake()
         } else if quit {
             break;
         }

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -1,6 +1,5 @@
-use fltk::{enums::*, prelude::*, *};
 use fltk_egui as egui_backend;
-use egui_backend::{DpiScaling, egui, gl};
+use egui_backend::{fltk::{enums::*, prelude::*, *}, DpiScaling, egui, gl};
 use std::rc::Rc;
 use std::{cell::RefCell, time::Instant};
 
@@ -34,10 +33,10 @@ fn main() {
         | enums::Event::Resize
         | enums::Event::Move
         | enums::Event::Drag => {
-            egui_backend::input_to_egui(
+		    let mut state = state.borrow_mut();
+            state.fuse_input(
                 win,
                 ev,
-                &mut state.borrow_mut(),
                 &mut painter.borrow_mut(),
             );
             true
@@ -83,23 +82,20 @@ fn main() {
         });
 
         let (egui_output, paint_cmds) = egui_ctx.end_frame();
-        egui_backend::translate_cursor(&mut win, &mut state.fuse_cursor, egui_output.cursor_icon);
-
-        //Handle cut, copy text from egui
-        if !egui_output.copied_text.is_empty() {
-            egui_backend::copy_to_clipboard(&mut state.clipboard, egui_output.copied_text);
-        }
-
+		state.fuse_output(&mut win, &egui_output);
+		
         let paint_jobs = egui_ctx.tessellate(paint_cmds);
 
         //Draw egui texture
         painter.paint_jobs(None, paint_jobs, &egui_ctx.texture());
-
-        win.swap_buffers();
+		
+		win.swap_buffers();
         win.flush();
-        app::sleep(0.006);
-        app::awake();
-        if quit {
+		
+		if egui_output.needs_repaint {
+			// let egui doing some animations.
+			app::awake()
+        } else if quit {
             break;
         }
     }

--- a/examples/demo_lib.rs
+++ b/examples/demo_lib.rs
@@ -1,5 +1,9 @@
+use egui_backend::{
+    egui,
+    fltk::{enums::*, prelude::*, *},
+    gl, DpiScaling,
+};
 use fltk_egui as egui_backend;
-use egui_backend::{fltk::{enums::*, prelude::*, *}, DpiScaling, egui, gl};
 use std::rc::Rc;
 use std::{cell::RefCell, time::Instant};
 
@@ -33,12 +37,8 @@ fn main() {
         | enums::Event::Resize
         | enums::Event::Move
         | enums::Event::Drag => {
-			let mut state = state.borrow_mut();
-            state.fuse_input(
-                win,
-                ev,
-                &mut painter.borrow_mut(),
-            );
+            let mut state = state.borrow_mut();
+            state.fuse_input(win, ev, &mut painter.borrow_mut());
             true
         }
         _ => false,
@@ -58,7 +58,7 @@ fn main() {
             gl::ClearColor(0.6, 0.3, 0.3, 1.0);
             gl::Clear(gl::COLOR_BUFFER_BIT);
         }
-        
+
         demo_windows.ui(&egui_ctx);
 
         let (egui_output, paint_cmds) = egui_ctx.end_frame();
@@ -71,10 +71,10 @@ fn main() {
 
         win.swap_buffers();
         win.flush();
-       	
-		if egui_output.needs_repaint {
-			// let egui doing some animations.
-			app::awake()
+
+        if egui_output.needs_repaint {
+            // let egui doing some animations.
+            app::awake()
         }
     }
 }

--- a/examples/demo_lib.rs
+++ b/examples/demo_lib.rs
@@ -1,6 +1,5 @@
-use fltk::{enums::*, prelude::*, *};
 use fltk_egui as egui_backend;
-use egui_backend::{DpiScaling, egui, gl};
+use egui_backend::{fltk::{enums::*, prelude::*, *}, DpiScaling, egui, gl};
 use std::rc::Rc;
 use std::{cell::RefCell, time::Instant};
 
@@ -34,10 +33,10 @@ fn main() {
         | enums::Event::Resize
         | enums::Event::Move
         | enums::Event::Drag => {
-            egui_backend::input_to_egui(
+			let mut state = state.borrow_mut();
+            state.fuse_input(
                 win,
                 ev,
-                &mut state.borrow_mut(),
                 &mut painter.borrow_mut(),
             );
             true
@@ -63,12 +62,7 @@ fn main() {
         demo_windows.ui(&egui_ctx);
 
         let (egui_output, paint_cmds) = egui_ctx.end_frame();
-        egui_backend::translate_cursor(&mut win, &mut state.fuse_cursor, egui_output.cursor_icon);
-
-        //Handle cut, copy text from egui
-        if !egui_output.copied_text.is_empty() {
-            egui_backend::copy_to_clipboard(&mut state.clipboard, egui_output.copied_text);
-        }
+        state.fuse_output(&mut win, &egui_output);
 
         let paint_jobs = egui_ctx.tessellate(paint_cmds);
 
@@ -77,7 +71,10 @@ fn main() {
 
         win.swap_buffers();
         win.flush();
-        app::sleep(0.006);
-        app::awake();
+       	
+		if egui_output.needs_repaint {
+			// let egui doing some animations.
+			app::awake()
+        }
     }
 }

--- a/examples/embedded.rs
+++ b/examples/embedded.rs
@@ -1,5 +1,9 @@
+use egui_backend::{
+    egui,
+    fltk::{enums::*, prelude::*, *},
+    gl, DpiScaling,
+};
 use fltk_egui as egui_backend;
-use egui_backend::{fltk::{enums::*, prelude::*, *}, DpiScaling, egui, gl};
 use std::rc::Rc;
 use std::{cell::RefCell, time::Instant};
 
@@ -25,7 +29,8 @@ fn main() {
     main_win.show();
     glut_win.make_current();
 
-    let (painter, egui_input_state) = egui_backend::with_fltk(&mut glut_win, DpiScaling::Custom(1.5));
+    let (painter, egui_input_state) =
+        egui_backend::with_fltk(&mut glut_win, DpiScaling::Custom(1.5));
     let mut egui_ctx = egui::CtxRef::default();
 
     let state_rc = Rc::from(RefCell::from(egui_input_state));
@@ -44,12 +49,8 @@ fn main() {
             | enums::Event::Move
             | enums::Event::Drag => {
                 let mut state = state.borrow_mut();
-                state.fuse_input(
-                    &mut w,
-                    ev,
-                    &mut painter.borrow_mut(),
-                );
-				true
+                state.fuse_input(&mut w, ev, &mut painter.borrow_mut());
+                true
             }
             _ => false,
         }
@@ -72,7 +73,7 @@ fn main() {
             gl::ClearColor(0.6, 0.3, 0.3, 1.0);
             gl::Clear(gl::COLOR_BUFFER_BIT);
         }
-		
+
         egui::CentralPanel::default().show(&egui_ctx, |ui| {
             ui.heading("My egui Application");
             ui.horizontal(|ui| {

--- a/examples/embedded.rs
+++ b/examples/embedded.rs
@@ -1,6 +1,5 @@
-use fltk::{enums::*, prelude::*, *};
 use fltk_egui as egui_backend;
-use egui_backend::{DpiScaling, egui, gl};
+use egui_backend::{fltk::{enums::*, prelude::*, *}, DpiScaling, egui, gl};
 use std::rc::Rc;
 use std::{cell::RefCell, time::Instant};
 
@@ -44,13 +43,13 @@ fn main() {
             | enums::Event::Resize
             | enums::Event::Move
             | enums::Event::Drag => {
-                egui_backend::input_to_egui(
+                let mut state = state.borrow_mut();
+                state.fuse_input(
                     &mut w,
                     ev,
-                    &mut state.borrow_mut(),
                     &mut painter.borrow_mut(),
                 );
-                true
+				true
             }
             _ => false,
         }
@@ -73,6 +72,7 @@ fn main() {
             gl::ClearColor(0.6, 0.3, 0.3, 1.0);
             gl::Clear(gl::COLOR_BUFFER_BIT);
         }
+		
         egui::CentralPanel::default().show(&egui_ctx, |ui| {
             ui.heading("My egui Application");
             ui.horizontal(|ui| {
@@ -95,12 +95,7 @@ fn main() {
         });
 
         let (egui_output, paint_cmds) = egui_ctx.end_frame();
-        egui_backend::translate_cursor(&mut glut_win, &mut state.fuse_cursor, egui_output.cursor_icon);
-
-        //Handle cut, copy text from egui
-        if !egui_output.copied_text.is_empty() {
-            egui_backend::copy_to_clipboard(&mut state.clipboard, egui_output.copied_text);
-        }
+        state.fuse_output(&mut glut_win, &egui_output);
 
         let paint_jobs = egui_ctx.tessellate(paint_cmds);
 

--- a/examples/triangle/main.rs
+++ b/examples/triangle/main.rs
@@ -1,6 +1,10 @@
-use fltk_egui as egui_backend;
-use egui_backend::{fltk::{enums::*, prelude::*, *}, DpiScaling, egui, gl};
 use egui::{vec2, Color32, Image};
+use egui_backend::{
+    egui,
+    fltk::{enums::*, prelude::*, *},
+    gl, DpiScaling,
+};
+use fltk_egui as egui_backend;
 use std::cell::RefCell;
 use std::rc::Rc;
 use std::time::Instant;
@@ -39,12 +43,8 @@ fn main() {
         | enums::Event::Move
         | enums::Event::Drag => {
             let mut state = state.borrow_mut();
-            state.fuse_input(
-                win,
-                ev,
-                &mut painter.borrow_mut(),
-            );
-			true
+            state.fuse_input(win, ev, &mut painter.borrow_mut());
+            true
         }
         _ => false,
     });
@@ -147,10 +147,10 @@ fn main() {
 
         win.swap_buffers();
         win.flush();
-		app::sleep(0.006);
-		app::awake();
-		if quit {
-			break;
-		}
+        app::sleep(0.006);
+        app::awake();
+        if quit {
+            break;
+        }
     }
 }

--- a/examples/triangle/main.rs
+++ b/examples/triangle/main.rs
@@ -1,6 +1,5 @@
-use fltk::{enums::*, prelude::*, *};
 use fltk_egui as egui_backend;
-use egui_backend::{DpiScaling, egui, gl};
+use egui_backend::{fltk::{enums::*, prelude::*, *}, DpiScaling, egui, gl};
 use egui::{vec2, Color32, Image};
 use std::cell::RefCell;
 use std::rc::Rc;
@@ -39,13 +38,13 @@ fn main() {
         | enums::Event::Resize
         | enums::Event::Move
         | enums::Event::Drag => {
-            egui_backend::input_to_egui(
+            let mut state = state.borrow_mut();
+            state.fuse_input(
                 win,
                 ev,
-                &mut state.borrow_mut(),
                 &mut painter.borrow_mut(),
             );
-            true
+			true
         }
         _ => false,
     });
@@ -136,12 +135,7 @@ fn main() {
         });
 
         let (egui_output, paint_cmds) = egui_ctx.end_frame();
-        egui_backend::translate_cursor(&mut win, &mut state.fuse_cursor, egui_output.cursor_icon);
-
-        //Handle cut, copy text from egui
-        if !egui_output.copied_text.is_empty() {
-            fltk_egui::copy_to_clipboard(&mut state.clipboard, egui_output.copied_text);
-        }
+        state.fuse_output(&mut win, &egui_output);
 
         let paint_jobs = egui_ctx.tessellate(paint_cmds);
 
@@ -153,10 +147,10 @@ fn main() {
 
         win.swap_buffers();
         win.flush();
-        app::sleep(0.006);
-        app::awake();
-        if quit {
-            break;
-        }
+		app::sleep(0.006);
+		app::awake();
+		if quit {
+			break;
+		}
     }
 }

--- a/examples/triangle/triangle.rs
+++ b/examples/triangle/triangle.rs
@@ -1,8 +1,8 @@
 // Draws a simple white triangle
 // based on the example from:
 // https://github.com/brendanzab/gl-rs/blob/master/gl/examples/triangle.rs
-use fltk_egui as egui_backend;
 use egui_backend::gl;
+use fltk_egui as egui_backend;
 use gl::types::*;
 use std::ffi::CString;
 use std::mem;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,18 +2,28 @@
 
 // Re-export dependencies.
 pub use egui;
-use fltk::*;
-use fltk::{prelude::*, window::GlutWindow};
-pub mod painter;
-use egui::*;
+pub use fltk;
+use fltk::{prelude::*, window::GlutWindow, enums, app};
+use egui::{pos2, Pos2, Key, Modifiers, Event, RawInput, CursorIcon};
 pub use gl;
-pub use painter::Painter;
-mod clipboard;
+mod painter;
+use painter::Painter;
 
-use clipboard::{
-    ClipboardContext, // TODO: remove
+#[cfg(feature = "clipboard")]
+use copypasta::{
+    ClipboardContext,
     ClipboardProvider,
 };
+
+#[cfg(not(feature = "clipboard"))]
+mod clipboard;
+
+#[cfg(not(feature = "clipboard"))]
+use clipboard::{
+    ClipboardContext,
+    ClipboardProvider,
+};
+
 
 pub fn with_fltk(
     win: &mut fltk::window::GlutWindow,
@@ -23,7 +33,7 @@ pub fn with_fltk(
         DpiScaling::Default => win.pixels_per_unit(),
         DpiScaling::Custom(custom) => custom,
     };
-    let painter = painter::Painter::new(win, scale);
+    let painter = Painter::new(win, scale);
     EguiInputState::new(painter)
 }
 
@@ -67,6 +77,22 @@ impl EguiInputState {
             modifiers: Modifiers::default(),
         };
         (painter, _self)
+    }
+	
+	pub fn fuse_input(
+        &mut self,
+        win: &mut fltk::window::GlutWindow,
+        event: enums::Event,
+        painter: &mut Painter,
+    ) {
+        input_to_egui(win, event, self, painter);
+    }
+
+    pub fn fuse_output(&mut self, win: &mut GlutWindow, egui_output: &egui::Output) {
+        if !egui_output.copied_text.is_empty() {
+            copy_to_clipboard(&mut self.clipboard, egui_output.copied_text.clone());
+        }
+        translate_cursor(win, &mut self.fuse_cursor, egui_output.cursor_icon);
     }
 }
 
@@ -153,13 +179,13 @@ pub fn input_to_egui(
                 };
 
                 if state.modifiers.command && key == Key::C {
-                    println!("copy event");
+                    // println!("copy event");
                     state.input.events.push(Event::Copy)
                 } else if state.modifiers.command && key == Key::X {
-                    println!("cut event");
+                    // println!("cut event");
                     state.input.events.push(Event::Cut)
                 } else if state.modifiers.command && key == Key::V {
-                    println!("paste");
+                    // println!("paste");
                     if let Some(clipboard) = state.clipboard.as_mut() {
                         match clipboard.get_contents() {
                             Ok(contents) => {
@@ -364,7 +390,8 @@ pub fn translate_cursor(
         CursorIcon::NotAllowed | CursorIcon::NoDrop => enums::Cursor::Wait,
         CursorIcon::Wait => enums::Cursor::Wait,
         //There doesn't seem to be a suitable SDL equivalent...
-        CursorIcon::Grab | CursorIcon::Grabbing => enums::Cursor::Move,
+        CursorIcon::Grab => enums::Cursor::Hand,
+        CursorIcon::Grabbing => enums::Cursor::Move,
 
         _ => enums::Cursor::Arrow,
     };
@@ -375,7 +402,7 @@ pub fn translate_cursor(
     }
 }
 
-pub fn init_clipboard() -> Option<ClipboardContext> {
+fn init_clipboard() -> Option<ClipboardContext> {
     match ClipboardContext::new() {
         Ok(clipboard) => Some(clipboard),
         Err(err) => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,28 +2,21 @@
 
 // Re-export dependencies.
 pub use egui;
+use egui::{pos2, CursorIcon, Event, Key, Modifiers, Pos2, RawInput};
 pub use fltk;
-use fltk::{prelude::*, window::GlutWindow, enums, app};
-use egui::{pos2, Pos2, Key, Modifiers, Event, RawInput, CursorIcon};
+use fltk::{app, enums, prelude::*, window::GlutWindow};
 pub use gl;
 mod painter;
 use painter::Painter;
 
 #[cfg(feature = "clipboard")]
-use copypasta::{
-    ClipboardContext,
-    ClipboardProvider,
-};
+use copypasta::{ClipboardContext, ClipboardProvider};
 
 #[cfg(not(feature = "clipboard"))]
 mod clipboard;
 
 #[cfg(not(feature = "clipboard"))]
-use clipboard::{
-    ClipboardContext,
-    ClipboardProvider,
-};
-
+use clipboard::{ClipboardContext, ClipboardProvider};
 
 pub fn with_fltk(
     win: &mut fltk::window::GlutWindow,
@@ -78,8 +71,8 @@ impl EguiInputState {
         };
         (painter, _self)
     }
-	
-	pub fn fuse_input(
+
+    pub fn fuse_input(
         &mut self,
         win: &mut fltk::window::GlutWindow,
         event: enums::Event,

--- a/src/painter.rs
+++ b/src/painter.rs
@@ -422,7 +422,7 @@ impl Painter {
     ) {
         self.upload_egui_texture(egui_texture);
         self.upload_user_textures();
-		
+
         unsafe {
             if let Some(color) = bg_color {
                 gl::ClearColor(
@@ -434,7 +434,7 @@ impl Painter {
 
                 gl::Clear(gl::COLOR_BUFFER_BIT);
             }
-			
+
             //Let OpenGL know we are dealing with SRGB colors so that it
             //can do the blending correctly. Not setting the framebuffer
             //leads to darkened, oversaturated colors.
@@ -445,16 +445,12 @@ impl Painter {
             gl::UseProgram(self.program);
             gl::ActiveTexture(gl::TEXTURE0);
             let (canvas_width, canvas_height) = self.canvas_size;
-			let pixels_per_point = self.pixels_per_point;
+            let pixels_per_point = self.pixels_per_point;
             let u_screen_size = CString::new("u_screen_size").unwrap();
             let u_screen_size_ptr = u_screen_size.as_ptr();
             let u_screen_size_loc = gl::GetUniformLocation(self.program, u_screen_size_ptr);
             let (x, y) = (self.screen_rect.width(), self.screen_rect.height());
-            gl::Uniform2f(
-                u_screen_size_loc,
-                x,
-				y,
-            );
+            gl::Uniform2f(u_screen_size_loc, x, y);
             let u_sampler = CString::new("u_sampler").unwrap();
             let u_sampler_ptr = u_sampler.as_ptr();
             let u_sampler_loc = gl::GetUniformLocation(self.program, u_sampler_ptr);
@@ -462,7 +458,7 @@ impl Painter {
             gl::Viewport(0, 0, canvas_width, canvas_height);
             let screen_x = canvas_width as f32;
             let screen_y = canvas_height as f32;
-			
+
             for ClippedMesh(clip_rect, mesh) in meshes {
                 gl::BindTexture(gl::TEXTURE_2D, self.get_texture(mesh.texture_id));
                 let clip_min_x = pixels_per_point * clip_rect.min.x;


### PR DESCRIPTION
- reduce CPU usage on example basic and demo_lib
- add a couple of fn (fuse_input and fuse_output) to reduce cumbersomeness.
- remove unnecessary cast (as i32).