### PR TITLE
Update README.md: optional clipboard feature not necessary anymore.

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,4 +30,4 @@ https://github.com/fltk-rs/demos/tree/master/egui-demo
 ## Todo
 - Properly handle resizing the GlutWindow: ✅
 - Support egui_demo_lib crate directly: ✅
-- Clipboard support (via optional features): ✅
+- Clipboard support: ✅

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,9 +11,9 @@
     fltk-egui = "0.3"
     ```
 
-    The basic premise is that egui is an immediate mode gui, while FLTK is retained. 
-    To be able to run Egui code, events and redrawing would need to be handled/done in the FLTK event loop. 
-    The events are those of the GlutWindow, which are sent to egui's event handlers. 
+    The basic premise is that egui is an immediate mode gui, while FLTK is retained.
+    To be able to run Egui code, events and redrawing would need to be handled/done in the FLTK event loop.
+    The events are those of the GlutWindow, which are sent to egui's event handlers.
     Other FLTK widgets can function also normally since there is no interference from Egui.
 
     ## Examples

--- a/src/painter.rs
+++ b/src/painter.rs
@@ -516,8 +516,8 @@ impl Painter {
                 }
             }
 
-            gl::Disable(gl::SCISSOR_TEST);
             gl::Disable(gl::FRAMEBUFFER_SRGB);
+            gl::Disable(gl::SCISSOR_TEST);
             gl::Disable(gl::BLEND);
         }
     }
@@ -643,9 +643,10 @@ impl Painter {
                 gl::UNSIGNED_SHORT,
                 ptr::null(),
             );
-            gl::DisableVertexAttribArray(a_srgba_loc);
-            gl::DisableVertexAttribArray(a_tc_loc);
+
             gl::DisableVertexAttribArray(a_pos_loc);
+            gl::DisableVertexAttribArray(a_tc_loc);
+            gl::DisableVertexAttribArray(a_srgba_loc);
         }
     }
 

--- a/src/painter.rs
+++ b/src/painter.rs
@@ -519,6 +519,7 @@ impl Painter {
 
             gl::Disable(gl::SCISSOR_TEST);
             gl::Disable(gl::FRAMEBUFFER_SRGB);
+			gl::Disable(gl::BLEND);
         }
     }
 
@@ -643,6 +644,9 @@ impl Painter {
                 gl::UNSIGNED_SHORT,
                 ptr::null(),
             );
+			gl::DisableVertexAttribArray(a_srgba_loc);
+			gl::DisableVertexAttribArray(a_tc_loc);
+			gl::DisableVertexAttribArray(a_pos_loc);
         }
     }
 

--- a/src/painter.rs
+++ b/src/painter.rs
@@ -105,7 +105,6 @@ const FS_SRC: &str = r#"
     }
 "#;
 
-
 /// Peforms egui's painting in the GlutWindow
 pub struct Painter {
     vertex_array: GLuint,
@@ -519,7 +518,7 @@ impl Painter {
 
             gl::Disable(gl::SCISSOR_TEST);
             gl::Disable(gl::FRAMEBUFFER_SRGB);
-			gl::Disable(gl::BLEND);
+            gl::Disable(gl::BLEND);
         }
     }
 
@@ -644,9 +643,9 @@ impl Painter {
                 gl::UNSIGNED_SHORT,
                 ptr::null(),
             );
-			gl::DisableVertexAttribArray(a_srgba_loc);
-			gl::DisableVertexAttribArray(a_tc_loc);
-			gl::DisableVertexAttribArray(a_pos_loc);
+            gl::DisableVertexAttribArray(a_srgba_loc);
+            gl::DisableVertexAttribArray(a_tc_loc);
+            gl::DisableVertexAttribArray(a_pos_loc);
         }
     }
 


### PR DESCRIPTION
current issue: 
- using "fltk-bundled" feature not work on x64-windows-msvc due to rust-lld: error: undefined symbol: Fl_compose,  Fl_compose_reset,  Fl_compose_state,  Fl_reset_marked_text,  Fl_insertion_point_location,  Fl_copy,  Fl_add_clipboard_notify and  Fl_remove_clipboard_notify. (something ain't right inside lib_x64-windows-msvc.tar.gz, will be fixed on the next update maybe?).

anyway, on linux working perfectly fine. great work thank you @MoAlyousef :)
