### PR TITLE
make painter public +update fltk-rs.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ readme = "README.md"
 license = "MIT"
 
 [dependencies]
-fltk = { version = "1.2.4", features = ["enable-glwindow"] }
+fltk = { version = "1.2.5", features = ["enable-glwindow"] }
 gl = "0.14"
 egui = "0.14"
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,7 +34,7 @@ pub use fltk;
 use fltk::{app, enums, prelude::*, window::GlutWindow};
 pub use gl;
 mod painter;
-use painter::Painter;
+pub use painter::Painter;
 
 /// Construct the backend.
 /// Requires the DpiScaling, which can be Default or Custom(f32)


### PR DESCRIPTION
make painter public so it's possible to integrate texture allocator with other 3rd party crates, (e.g: image support since currently there's no way to convert fltk image to egui::Image widget) 